### PR TITLE
Add social links across site

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,6 +10,10 @@
     <h1 class="display-4">404</h1>
     <p class="lead">That page doesn’t exist… yet.</p>
     <a href="/" class="btn btn-primary">Back to home</a>
+    <div class="mt-4">
+      <a href="https://github.com/ryanrslater" class="text-decoration-none me-3" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.linkedin.com/in/ryan-slater-ba2304234/" class="text-decoration-none" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
   </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -129,6 +129,10 @@
               Expect technical breakdowns, architecture notes, experiments, and mistakes.
               Lots of mistakes.
             </p>
+              <div class="d-flex justify-content-center gap-3">
+                <a href="https://github.com/ryanrslater" class="text-decoration-none" target="_blank" rel="noopener">GitHub</a>
+                <a href="https://www.linkedin.com/in/ryan-slater-ba2304234/" class="text-decoration-none" target="_blank" rel="noopener">LinkedIn</a>
+              </div>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -151,9 +151,13 @@
   <!-- FOOTER -->
 
   <footer class="bg-light py-4 text-center">
-    <p class="mb-0">
+    <p class="mb-1">
       <strong>Ryan.Log</strong> by Ryan — Powered by Bootstrap.
     </p>
+    <div class="d-flex justify-content-center gap-3">
+      <a href="https://github.com/ryanrslater" class="text-decoration-none" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.linkedin.com/in/ryan-slater-ba2304234/" class="text-decoration-none" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
   </footer>
 
   <!-- Bootstrap JS -->

--- a/post-first-serverless-platform.html
+++ b/post-first-serverless-platform.html
@@ -104,7 +104,11 @@
   </main>
 
   <footer class="bg-light py-4 text-center">
-    <p class="mb-0"><strong>Ryan.Log</strong> by Ryan — Powered by Bootstrap.</p>
+    <p class="mb-1"><strong>Ryan.Log</strong> by Ryan — Powered by Bootstrap.</p>
+    <div class="d-flex justify-content-center gap-3">
+      <a href="https://github.com/ryanrslater" class="text-decoration-none" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.linkedin.com/in/ryan-slater-ba2304234/" class="text-decoration-none" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- add GitHub and LinkedIn links to the site footer
- expose the same social links on the 404 page

## Testing
- not run (static site changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef1ae21ec8327a2bda2944246f4dd)